### PR TITLE
fix(fetchBatch): fix duplicate and missing fetchBatch result data

### DIFF
--- a/lib/core/Metadata.js
+++ b/lib/core/Metadata.js
@@ -3,6 +3,6 @@
 exports.ModuleMetadata = {
   Engine: 'iamx-redash',
   Name: 'IAMX Redash Connector',
-  Version: '0.1.3',
+  Version: '0.1.4',
   SupportedExecution: [ 'provision', 'revoke', 'show', 'fetchBatch' ]
 };

--- a/lib/core/iterator.js
+++ b/lib/core/iterator.js
@@ -18,7 +18,11 @@ class BatchIterator {
     this.pageSize = object.pageSize;
     this.page = object.page;
     this.count = object.count;
-    this.order = object.order;
+
+    this.order = 'created_at';
+    if (object.order) {
+      this.order = object.order;
+    }
   }
 
   hasNext() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cermati/iamx-redash-connector",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cermati/iamx-redash-connector",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Redash Connector for IAMX",
   "main": "lib/index.js",
   "dependencies": {


### PR DESCRIPTION
Fix duplicate and missing fetchBatch result data caused by `order` query options are not passed correctly when the `queryOptions` is empty.